### PR TITLE
Start using mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
     - pip install . --use-mirrors
     - pip install requests --use-mirrors
     - pip install flake8
+    - pip install mock --use-mirrors
     - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 --use-mirrors; fi"
 script:
     - nosetests

--- a/test/_common.py
+++ b/test/_common.py
@@ -8,11 +8,13 @@ try:
 except ImportError:
     import unittest
 
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
 sys.path.insert(0, '..')
 
-
-class TestCast(unittest.TestCase):
-    pass
 
 model_names = {
     'user': models.User,
@@ -23,14 +25,6 @@ model_names = {
     'milestone': models.Milestone,
     'component': models.Component,
 }
-
-
-class MockBase(object):
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
 
 
 class MockAPI(object):

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,12 @@ deps =
 deps =
     {[testenv]deps}
     unittest2
+    mock
+
+[testenv:py27]
+deps =
+    {[testenv]deps}
+    mock
 
 [testenv:flake8]
 commands = flake8 --ignore=E501 assembla


### PR DESCRIPTION
I wasn't too satisfied with the current way to mock objects, so I started researching about it. The [Mock library](http://www.voidspace.org.uk/python/mock/) is actually part of the standard library in Python >= 3.3; so, looking to the future, it won't be another testing dependency (which is best to keep to a minimum).

I want some feedback on this, but I think this is the way.
