### PR TITLE
Lazy load related objects

### DIFF
--- a/assembla/models.py
+++ b/assembla/models.py
@@ -14,6 +14,19 @@ class Model(object):
     def instantiate_many(cls, json, api):
         return [cls.instantiate_one(entity, api) for entity in json]
 
+    def __init__(self, lazy_load=None):
+        if lazy_load:
+            self.lazy_load = lazy_load
+
+    def __getattr__(self, name):
+        if name != 'lazy_load' and self.lazy_load:
+            api, json = self.lazy_load()
+            attrs = parsers.parse(json, api)
+            for key, value in attrs.items():
+                setattr(self, key, value)
+            delattr(self, 'lazy_load')
+            return getattr(self, name)
+
 
 class User(Model):
     pass

--- a/assembla/parsers.py
+++ b/assembla/parsers.py
@@ -49,12 +49,12 @@ def parse(json, api):
         if key in user_fields:
             key = key.replace('_id', '')
             if value:
-                value = api.user(id=value)
+                value = api.user(id=value, lazy=True)
 
         elif key in foreign_fields:
             key = key.replace('_id', '')
             if value:
-                value = getattr(api, key)(id=value)
+                value = getattr(api, key)(id=value, lazy=True)
 
         elif key in float_fields:
             if value:


### PR DESCRIPTION
When fetching a object that is related to other objects, we shouldn't load the related ones right away, but instead only load when (and if) necessary.

I'm not sure if this is best implementation, tell me what you think about it later.
